### PR TITLE
fix(ship): stream blocks on the normal CAS path (SHiP streamed zero blocks)

### DIFF
--- a/crates/pulsevm/src/state_history/session.rs
+++ b/crates/pulsevm/src/state_history/session.rs
@@ -14,7 +14,7 @@ use pulsevm_core::{
 };
 use pulsevm_crypto::Bytes;
 use pulsevm_serialization::{Read, Write};
-use spdlog::{debug, info};
+use spdlog::{debug, error, info, warn};
 use tokio::{
     sync::{
         RwLock, mpsc,
@@ -150,10 +150,12 @@ impl Session {
                                             Ordering::SeqCst,
                                             Ordering::SeqCst,
                                         )
-                                        .is_ok()
+                                        .is_err()
                                     {
-                                        break;
+                                        // lost the race for a slot; retry acquisition
+                                        continue;
                                     }
+                                    // slot acquired: fall through and stream this block
 
                                     match make_block_response_for(ctrl.clone(), &request, next)
                                         .await
@@ -177,7 +179,10 @@ impl Session {
                                                         break;
                                                     }
                                                 }
-                                                Err(_) => {
+                                                Err(e) => {
+                                                    error!(
+                                                        "[ship] failed to pack block response for block {next}: {e}"
+                                                    );
                                                     // give window slot back
                                                     budget.fetch_add(1, Ordering::SeqCst);
                                                     tokio::time::sleep(Duration::from_millis(5))
@@ -185,9 +190,12 @@ impl Session {
                                                 }
                                             }
                                         }
-                                        Err(_) => {
+                                        Err(e) => {
                                             // Likely "block not ready yet" — backoff and retry
                                             // return slot because nothing was sent
+                                            warn!(
+                                                "[ship] make_block_response_for failed for block {next}: {e}"
+                                            );
                                             budget.fetch_add(1, Ordering::SeqCst);
                                             tokio::time::sleep(Duration::from_millis(500)).await;
                                         }
@@ -247,20 +255,29 @@ impl Session {
         let head_block = controller.last_accepted_block();
         let head_block_id = head_block.id()?;
 
+        // Serveable end is bounded by what is actually appended to block_log on disk.
+        // last_accepted can run ~1 block ahead; advertising it as the head/end makes the
+        // reader request a block read_block cannot yet serve, stalling indexing.
+        let serveable = controller.block_log().map(|l| l.last_block()).unwrap_or(0);
+        let serveable_head_id = controller
+            .get_block_id(serveable)
+            .await?
+            .unwrap_or(head_block_id);
+
         Ok(GetStatusResult {
             variant: 0,
             head: BlockPosition {
-                block_num: head_block.block_num(),
-                block_id: head_block_id,
+                block_num: serveable,
+                block_id: serveable_head_id,
             },
             last_irreversible: BlockPosition {
                 block_num: head_block.block_num(),
                 block_id: head_block_id,
             },
             trace_begin_block: 1,
-            trace_end_block: head_block.block_num(),
+            trace_end_block: serveable,
             chain_state_begin_block: 1,
-            chain_state_end_block: head_block.block_num(),
+            chain_state_end_block: serveable,
             chain_id: chain_id.clone(),
         })
     }
@@ -314,7 +331,12 @@ async fn make_block_response_for(
     let controller = controller.read().await;
     let head = controller.last_accepted_block();
 
-    if head.block_num() < block_num {
+    // Serveability bound: only advertise/serve blocks actually appended to block_log.
+    // last_accepted can run ~1 block ahead of what is on disk, and read_block would
+    // then return NotFound, stalling the reader. Bound the head to the on-disk last block.
+    let serveable = controller.block_log().map(|l| l.last_block()).unwrap_or(0);
+
+    if serveable < block_num {
         return Err(anyhow!("block {block_num} not yet available"));
     }
 
@@ -336,10 +358,20 @@ async fn make_block_response_for(
 
     let mut block: Option<Bytes> = None;
     if request.fetch_block {
-        let signed_block = controller
-            .get_block(this_block_id)
+        let signed_block = match controller
+            .get_block_by_height(block_num)
             .map_err(|e| anyhow!("failed to get block {block_num} by id {this_block_id:?}: {e}"))?
-            .unwrap();
+        {
+            Some(b) => b,
+            None => {
+                error!(
+                    "[ship] get_block returned None for block {block_num} id {this_block_id:?} (read_block failed for synced block); aborting response build",
+                );
+                return Err(anyhow!(
+                    "get_block returned None for block {block_num} id {this_block_id:?}",
+                ));
+            }
+        };
         let signed_block_packed = signed_block.pack()?;
         block = Some(Bytes::new(signed_block_packed));
     }
@@ -374,11 +406,16 @@ async fn make_block_response_for(
         }
     }
 
+    let serveable_head_id = controller
+        .get_block_id(serveable)
+        .await?
+        .unwrap_or(head_block_id);
+
     Ok(GetBlocksResponseV0 {
         variant: 1,
         head: BlockPosition {
-            block_num: head.block_num(),
-            block_id: head_block_id,
+            block_num: serveable,
+            block_id: serveable_head_id,
         },
         last_irreversible: BlockPosition {
             block_num: head.block_num(),

--- a/crates/pulsevm_core/src/chain/state_history/log.rs
+++ b/crates/pulsevm_core/src/chain/state_history/log.rs
@@ -8,6 +8,7 @@ use std::{
 };
 
 use pulsevm_crypto::FixedBytes;
+use spdlog::{error, warn};
 
 use crate::chain::id::Id;
 
@@ -254,18 +255,38 @@ impl StateHistoryLog {
     pub fn read_block(&self, block_num: u32) -> Result<Vec<u8>, ShLogError> {
         let pos = {
             let m = self.map.lock().unwrap();
-            *m.get(&block_num).ok_or(ShLogError::NotFound(block_num))?
+            match m.get(&block_num) {
+                Some(p) => *p,
+                None => {
+                    warn!(
+                        "[ship][{}] read_block NotFound: block_num={} not in map (map_len={})",
+                        self.name,
+                        block_num,
+                        m.len()
+                    );
+                    return Err(ShLogError::NotFound(block_num));
+                }
+            }
         };
         let mut f = OpenOptions::new().read(true).open(&self.log_path)?;
         let header = StateHistoryLogHeader::read_at(&mut f, pos)?;
         if header.magic != self.magic {
+            error!(
+                "[ship][{}] read_block BadMagic: block_num={} pos={} found={:#x} expect={:#x}",
+                self.name, block_num, pos, header.magic, self.magic
+            );
             return Err(ShLogError::BadMagic {
                 at: pos,
                 found: header.magic,
                 expect: self.magic,
             });
         }
-        if num_from_block_id(&header.block_id) != block_num {
+        let stored_num = num_from_block_id(&header.block_id);
+        if stored_num != block_num {
+            error!(
+                "[ship][{}] read_block Corrupt: requested block_num={} pos={} but stored id encodes block_num={} (id={:?})",
+                self.name, block_num, pos, stored_num, header.block_id
+            );
             return Err(ShLogError::Corrupt(pos));
         }
         let mut buf = vec![0u8; header.payload_size as usize];
@@ -387,6 +408,10 @@ impl StateHistoryLog {
             (*(self as *const _ as *mut Self)).first_block = start_block;
         }
         Ok(())
+    }
+
+    pub fn last_block(&self) -> u32 {
+        self.last_block
     }
 
     pub fn range(&self) -> Option<(u32, u32)> {


### PR DESCRIPTION
## Summary

The state-history (SHiP) streamer accepted a connection, sent the ABI, then streamed **zero blocks** — leaving any consumer (Hyperion, in our case) stuck at `R:0` / "No blocks are being processed" despite a healthy, producing chain.

Root cause is a control-flow bug in the streamer's backpressure loop in `crates/pulsevm/src/state_history/session.rs`. The in-flight-budget acquisition used:

```rust
if budget.compare_exchange(current, current - 1, …).is_ok() {
    break;            // <- exits the ENTIRE streaming loop on the NORMAL path
}
match make_block_response_for(…)   // <- never reached
```

`break` was written as if there were an inner CAS-retry loop, but this is the single streaming `loop`. So **acquiring a slot (the normal case) broke out of the whole task before a block was ever built or sent.** The task terminated after one iteration.

Fix: invert to `.is_err() { continue }` (retry acquisition only when we lose the race) and fall through to stream the block.

## Also in this PR (tip-of-chain serveability)

While verifying the fix, a second, related stall surfaced at the live head: `last_accepted` can run ~1 block ahead of what's actually appended to `block_log` on disk. Advertising `last_accepted` as the head made the reader immediately request a block that `read_block` returns `NotFound` for, re-stalling indexing at the tip.

- `get_status` and the `GetBlocksResponseV0` head now report the **serveable** block (`block_log().last_block()`), not `last_accepted`.
- `make_block_response_for` fetches by height (`get_block_by_height`) and returns a **logged `Err`** instead of `unwrap()`-panicking when a synced block can't be read.
- Adds `StateHistoryLog::last_block()` accessor (`crates/pulsevm_core/src/chain/state_history/log.rs`).
- De-swallows the streamer's `Err(_)` arms (`warn!`/`error!`) and adds NotFound/BadMagic/Corrupt diagnostics in `read_block` — these are what made the zero-block case diagnosable (the tell was *zero* `make_block_response_for` log lines on a live connection).

The CAS one-liner is the load-bearing change; the serveability bound is required to stay caught up at the tip.

## Verification (A-Chain Alpine, v0.3.2 base `e168e43`)

- Built clean; deployed to a live Alpine validator.
- Before: consumer stuck at `R:0 | D:0 | I:0`, ES `last_indexed_block` frozen.
- After: ES `last_indexed_block` catches up to `head_block_num` (= LIB), **lag 0**, and `/v2/history/get_actions?sort=desc` returns current `pulse.token::transfer` actions at the live head.

## Files

- `crates/pulsevm/src/state_history/session.rs` — CAS fix, serveable head bound, error logging
- `crates/pulsevm_core/src/chain/state_history/log.rs` — `last_block()` accessor, read_block diagnostics