### PR TITLE
rpc: derive getInfo version fields from build metadata

### DIFF
--- a/crates/pulsevm/build.rs
+++ b/crates/pulsevm/build.rs
@@ -1,0 +1,29 @@
+use std::process::Command;
+
+fn git(args: &[&str]) -> Option<String> {
+    let out = Command::new("git").args(args).output().ok()?;
+    if !out.status.success() {
+        return None;
+    }
+    let s = String::from_utf8(out.stdout).ok()?.trim().to_string();
+    if s.is_empty() { None } else { Some(s) }
+}
+
+fn main() {
+    // PULSEVM_VERSION overrides for builds without a .git directory (e.g. from
+    // a source tarball); otherwise derive from the checkout: a tagged release
+    // build reports the tag (v0.3.5), anything else tag-distance + commit.
+    let version = std::env::var("PULSEVM_VERSION")
+        .ok()
+        .or_else(|| git(&["describe", "--tags", "--always", "--dirty"]))
+        .unwrap_or_else(|| "unknown".to_string());
+    let commit_long = git(&["rev-parse", "HEAD"]).unwrap_or_else(|| "unknown".to_string());
+    let commit_short = commit_long.get(0..8).unwrap_or("unknown").to_string();
+
+    println!("cargo:rustc-env=PULSEVM_VERSION={version}");
+    println!("cargo:rustc-env=PULSEVM_COMMIT={commit_short}");
+    println!("cargo:rustc-env=PULSEVM_COMMIT_LONG={commit_long}");
+    println!("cargo:rerun-if-changed=../../.git/HEAD");
+    println!("cargo:rerun-if-changed=../../.git/refs/tags");
+    println!("cargo:rerun-if-env-changed=PULSEVM_VERSION");
+}

--- a/crates/pulsevm/src/chain/service.rs
+++ b/crates/pulsevm/src/chain/service.rs
@@ -277,7 +277,7 @@ impl RpcServer for RpcService {
         let head_block_id = head_block.id()?;
 
         Ok(GetInfoResponse {
-            server_version: "d133c641".to_owned(),
+            server_version: env!("PULSEVM_COMMIT").to_owned(),
             server_time: BlockTimestamp::now(),
             chain_id: controller.chain_id().clone(),
             head_block_num: head_block.block_num(),
@@ -290,11 +290,15 @@ impl RpcServer for RpcService {
             virtual_block_net_limit: db.get_virtual_block_net_limit()?,
             block_cpu_limit: db.get_block_cpu_limit()?,
             block_net_limit: db.get_block_net_limit()?,
-            server_version_string: "v5.0.3".to_owned(),
+            server_version_string: env!("PULSEVM_VERSION").to_owned(),
             fork_db_head_block_id: head_block_id,
             fork_db_head_block_num: head_block.block_num(),
-            server_full_version_string: "v5.0.3-d133c6413ce8ce2e96096a0513ec25b4a8dbe837"
-                .to_owned(), // Mimic EOS here
+            server_full_version_string: concat!(
+                env!("PULSEVM_VERSION"),
+                "-",
+                env!("PULSEVM_COMMIT_LONG")
+            )
+            .to_owned(), // Mimic EOS vX.Y.Z-<commit> format
             total_cpu_weight: db.get_total_cpu_weight()?,
             total_net_weight: db.get_total_net_weight()?,
             earliest_available_block_num: 1,


### PR DESCRIPTION
## Why

`server_version`, `server_version_string` and `server_full_version_string` in `getInfo` are hardcoded (`d133c641` / `v5.0.3`). During yesterday's v0.3.5 fleet rollout we had to ssh into every node and sha256 the plugin binaries to verify what was actually running — the RPC can't tell you.

## What

A small `build.rs` in `crates/pulsevm` derives the values at compile time:

- `server_version_string` ← `git describe --tags --always --dirty` (a release build from a tag reports `v0.3.5`; dev builds report `v0.3.5-N-g<short>`)
- `server_version` ← short commit, `server_full_version_string` ← `<describe>-<full commit>` (keeps the EOS `vX.Y.Z-<commit>` shape)
- builds without a `.git` dir (source tarballs) can override via `PULSEVM_VERSION` env

No runtime cost — values are baked in via `rustc-env`/`env!`.

## Verified live

Running on the protonnz public endpoint now:

```
"server_version": "11486818",
"server_version_string": "v0.3.5-1-g1148681",
"server_full_version_string": "v0.3.5-1-g1148681-114868181a3dedc62b475b991240bdf565482b03"
```

```bash
curl -s -X POST -H 'content-type: application/json' \
  -d '{"jsonrpc":"2.0","id":1,"method":"pulsevm.getInfo","params":{}}' \
  https://a-chain-testnet.protonnz.com/ext/bc/6v9NieZiX3e8eQz3CyJMtXB6YzV2RtnxcRyLAmSgFWWk5Qs6y/rpc
```

Note for the release workflow: `git describe` needs tags available in the checkout (`fetch-depth: 0` or `fetch-tags: true` on actions/checkout), else it falls back to the bare commit hash — still correct, just less pretty.