### PR TITLE
chain: don't rebuild a transaction already in a pending block (halt fix)

### DIFF
--- a/crates/pulsevm_core/src/chain/controller.rs
+++ b/crates/pulsevm_core/src/chain/controller.rs
@@ -247,8 +247,30 @@ impl Controller {
         let timestamp = BlockTimestamp::now();
         let block_status = BlockStatus::Building;
 
+        // Transactions already present in a verified-but-not-yet-accepted block
+        // must not be included again. At build time the earlier block has not
+        // committed its `transaction_object` dedup record yet, so a re-gossiped
+        // copy of one of its transactions passes `record_transaction` here and
+        // gets packed into this block too. The duplicate is only detected later,
+        // when this block is verified after the earlier one is accepted — at
+        // which point `record_transaction` fails permanently and the block can
+        // never validate, halting the chain (it is retried forever by consensus).
+        // Defer such transactions instead of dropping them: if the pending block
+        // is accepted they are removed from the mempool then; if it is rejected
+        // on a fork they remain available for a later block.
+        let pending_tx_ids: HashSet<Id> = self
+            .verified_blocks
+            .values()
+            .flat_map(|b| b.transactions.iter().map(|r| r.trx().id().clone()))
+            .collect();
+        let mut deferred: Vec<PackedTransaction> = Vec::new();
+
         // Get transactions from the mempool
         while let Some(transaction) = mempool.pop_transaction() {
+            if pending_tx_ids.contains(transaction.id()) {
+                deferred.push(transaction);
+                continue;
+            }
             let mut child_session = db.create_undo_session(true)?;
             let transaction_result =
                 self.execute_transaction(&transaction, &timestamp, &block_status);
@@ -279,6 +301,11 @@ impl Controller {
                     })?; // Revert changes made during this transaction
                 }
             }
+        }
+
+        // Return deferred transactions to the mempool for a later block.
+        for tx in deferred {
+            mempool.add_transaction(&tx);
         }
 
         // Don't build a block if we have no transactions


### PR DESCRIPTION
## Incident

A-Chain Alpine halted at block **260163** on 2026-06-10 (~2¼h after upgrading v0.3.2 → v0.3.5). Every node logged, ~1/s, indefinitely:

```
could not verify block: DatabaseError("duplicate tx: ... duplicate transaction 04bc78cf...")
```

`04bc78cf` was a transfer **already accepted in 260163**; block **260164** also contained it, so 260164 could never verify. Recovery required a coordinated restart of all subnet validators (a single-node restart / resync / our-side fleet restart all failed — peers re-gossiped the poisoned block).

## Root cause

`build_block` executes and `record_transaction`s each tx inside a speculative undo session that is **reverted** at the end, so the dedup record in `transaction_object` is only committed in `accept_block` (`root_session.push()`). Between building block N and accepting it:

1. tx `T` is packed into N and popped from the mempool; N is broadcast
2. a peer re-gossips `T`; `mempool.add_transaction` re-accepts it (mempool dedup only covers the *current* queue — `mempool.rs:31-38`)
3. `build_block(N+1)` runs while N is **not yet accepted**, so `T` is absent from `transaction_object` → `record_transaction(T)` succeeds → N+1 is packed with `T`
4. N is accepted → `T` committed
5. N+1 verify → `record_transaction(T)` → `tx_duplicate` → `verify_block` returns `Err` before inserting into `verified_blocks` (`controller.rs:356`) → retried forever

The April fixes (`a4e6266`, `e168e43`) handled re-accepting an *already-accepted* block, but not a **pending** block whose tx later becomes a duplicate.

## Fix

In `build_block`, before packing, collect tx ids already present in any verified-but-not-yet-accepted block (`self.verified_blocks`) and **defer** (not drop) any mempool tx in that set:

- if the pending block is accepted, the tx is removed from the mempool then
- if it is rejected on a fork, the tx stays queued for a later block

No proposer mints a block containing a tx that's in a pending block → the poisoned block is never created.

## Status / caveats

- Diagnosis is backed by a live repro + archived poisoned chain state + the exact failing path.
- The multi-node gossip race isn't reproducible in the single-node unit harness, so this is **reasoned-correct, not test-proven** — posting as a proposal for review since it touches block production. Compiles clean.
- **Recommended follow-up, not in this PR (your call on mechanism):** a block that fails verification *deterministically* (e.g. `tx_duplicate`) should be rejected so consensus stops re-verifying/re-importing it, instead of retrying ~1/s forever. Without it, any future class of invalid block is still a network-stopper requiring a coordinated restart.