### PR TITLE
fix: surface assert messages and bound assert message reads

### DIFF
--- a/crates/pulsevm_core/src/chain/webassembly/system.rs
+++ b/crates/pulsevm_core/src/chain/webassembly/system.rs
@@ -22,22 +22,29 @@ pub fn eosio_assert(
             .as_ref()
             .expect("Wasm memory not initialized");
         let view = memory.view(&store);
-        let slice = msg_ptr.slice(&view, MAX_ASSERT_MESSAGE as u32)?;
-        let mut src_bytes = vec![0u8; MAX_ASSERT_MESSAGE];
-        slice.read_slice(&mut src_bytes)?;
-        let c_str = String::from_utf8(src_bytes);
 
-        match c_str {
-            Ok(msg_str) => {
-                return Err(RuntimeError::new(format!(
-                    "pulse assert failed: {}",
-                    msg_str
-                )));
-            }
-            Err(_) => {
-                return Err(RuntimeError::new("pulse assert failed"));
-            }
+        // The message is a NUL-terminated C string of unknown length. Reading a
+        // fixed MAX_ASSERT_MESSAGE window grabs whatever follows the terminator
+        // (and traps OOB when the string sits near the end of linear memory), and
+        // that trailing garbage then fails strict UTF-8 validation — collapsing
+        // every assert to a message-less "pulse assert failed". Clamp the window
+        // to the memory bounds, cut at the terminator, and decode lossily.
+        let offset = msg_ptr.offset() as u64;
+        let mem_size = view.data_size();
+        let window = mem_size.saturating_sub(offset).min(MAX_ASSERT_MESSAGE as u64);
+        if window == 0 {
+            return Err(RuntimeError::new("pulse assert failed"));
         }
+        let slice = msg_ptr.slice(&view, window as u32)?;
+        let mut src_bytes = vec![0u8; window as usize];
+        slice.read_slice(&mut src_bytes)?;
+        let len = src_bytes
+            .iter()
+            .position(|&b| b == 0)
+            .unwrap_or(src_bytes.len());
+        let msg = String::from_utf8_lossy(&src_bytes[..len]);
+
+        return Err(RuntimeError::new(format!("pulse assert failed: {}", msg)));
     }
 
     Ok(())
@@ -62,22 +69,18 @@ pub fn pulse_assert(
             .as_ref()
             .expect("Wasm memory not initialized");
         let view = memory.view(&store);
-        let slice = msg_ptr.slice(&view, msg_len)?;
-        let mut src_bytes = vec![0u8; msg_len as usize];
-        slice.read_slice(&mut src_bytes)?;
-        let c_str = String::from_utf8(src_bytes);
 
-        match c_str {
-            Ok(msg_str) => {
-                return Err(RuntimeError::new(format!(
-                    "pulse assert failed: {}",
-                    msg_str
-                )));
-            }
-            Err(_) => {
-                return Err(RuntimeError::new("pulse assert failed"));
-            }
-        }
+        // Bounds-check the full msg_len before truncation (an oversized len must
+        // trap as OOB, not silently clamp) — same contract as pulse_assert_message.
+        let slice = msg_ptr.slice(&view, msg_len)?;
+        let sz = (msg_len as usize).min(MAX_ASSERT_MESSAGE);
+        let mut src_bytes = vec![0u8; sz];
+        slice.subslice(0..sz as u64).read_slice(&mut src_bytes)?;
+
+        // Lossy decode so the message always surfaces — strict validation turned
+        // any stray non-UTF-8 byte into a message-less "pulse assert failed".
+        let msg = String::from_utf8_lossy(&src_bytes);
+        return Err(RuntimeError::new(format!("pulse assert failed: {}", msg)));
     }
 
     Ok(())


### PR DESCRIPTION
## Problem

Failing string-literal `check()`s in C++ contracts surface as a bare, message-less error:

```
wasm runtime error: apply error: pulse assert failed
```

Cause: `system.rs::eosio_assert` (the NUL-terminated C-string variant) reads a **fixed 1024-byte window** — no terminator scan — then strict-decodes with `String::from_utf8`. The bytes after the terminator are arbitrary linear memory, so decoding almost always fails and the `Err(_)` arm discards the message. Verified live on v0.3.8: literal `check()`s lose their message, while len-based asserts with clean ASCII (`pulse assert failed: no balance object found`) survive.

Two side defects in the same path:
- the fixed read **traps OOB** when the string sits within 1024 bytes of the end of linear memory;
- `pulse_assert` also strict-decodes, and its `msg_len` allocation is uncapped.

## Fix

`system.rs` only — brings both variants in line with `pulse_assert_message`, which already does this correctly:

- **`eosio_assert`**: clamp the window to `min(1024, mem_size - ptr)`, cut at the first NUL, decode with `from_utf8_lossy`.
- **`pulse_assert`**: bounds-check the full `msg_len` (oversized still traps OOB), truncate to 1024, decode lossily.

Error format unchanged (`pulse assert failed: <msg>`). Not consensus-affecting: failed transactions never enter blocks; only the speculative-execution error string changes.

`cargo check -p pulsevm_core` green. Happy to add WAST regression tests (clean message / non-UTF-8 tail / string near end of memory) if wanted.
