### PR TITLE
rpc: accept standard Antelope client param shapes in getTableRows

### DIFF
--- a/crates/pulsevm/src/chain/service.rs
+++ b/crates/pulsevm/src/chain/service.rs
@@ -11,7 +11,7 @@ use pulsevm_core::{
     mempool::Mempool,
     name::Name,
     transaction::{PackedTransaction, Transaction, TransactionCompression},
-    utils::{Base64Bytes, I32Flex},
+    utils::{Base64Bytes, I32Flex, StringFlex},
 };
 use pulsevm_crypto::{Bytes, Digest};
 use pulsevm_serialization::Read;
@@ -102,13 +102,13 @@ pub trait Rpc {
         &self,
         json: Option<bool>,
         code: Name,
-        scope: String,
+        scope: StringFlex,
         table: Name,
-        table_key: Option<String>,
-        lower_bound: Option<String>,
-        upper_bound: Option<String>,
+        table_key: Option<StringFlex>,
+        lower_bound: Option<StringFlex>,
+        upper_bound: Option<StringFlex>,
         limit: Option<I32Flex>,
-        key_type: String,
+        key_type: Option<String>,
         index_position: Option<I32Flex>,
         encode_type: Option<String>, //dec, hex , default=dec
         reverse: Option<bool>,
@@ -447,13 +447,13 @@ impl RpcServer for RpcService {
         &self,
         json: Option<bool>,
         code: Name,
-        scope: String,
+        scope: StringFlex,
         table: Name,
-        table_key: Option<String>,
-        lower_bound: Option<String>,
-        upper_bound: Option<String>,
+        table_key: Option<StringFlex>,
+        lower_bound: Option<StringFlex>,
+        upper_bound: Option<StringFlex>,
         limit: Option<I32Flex>,
-        key_type: String,
+        key_type: Option<String>,
         index_position: Option<I32Flex>,
         encode_type: Option<String>, //dec, hex , default=dec
         reverse: Option<bool>,
@@ -461,16 +461,21 @@ impl RpcServer for RpcService {
     ) -> Result<Value, ErrorObjectOwned> {
         let controller = self.controller.read().await;
         let db = controller.database();
+        // eosjs-style clients send limit: -1 for "no limit"
+        let limit = match limit.unwrap_or(I32Flex(10)).0 {
+            v if v < 0 => u32::MAX,
+            v => v as u32,
+        };
         let response = db.get_table_rows(
             json.unwrap_or(false),
             code.as_u64(),
-            &scope,
+            &scope.0,
             table.as_u64(),
-            &table_key.unwrap_or_default(),
-            &lower_bound.unwrap_or_default(),
-            &upper_bound.unwrap_or_default(),
-            limit.unwrap_or(I32Flex(10)).0 as u32,
-            &key_type,
+            &table_key.unwrap_or_default().0,
+            &lower_bound.unwrap_or_default().0,
+            &upper_bound.unwrap_or_default().0,
+            limit,
+            &key_type.unwrap_or_default(),
             &index_position.unwrap_or(I32Flex(1)).0.to_string(),
             &encode_type.unwrap_or_else(|| "dec".to_string()),
             reverse.unwrap_or(false),

--- a/crates/pulsevm_core/src/chain/utils/mod.rs
+++ b/crates/pulsevm_core/src/chain/utils/mod.rs
@@ -7,6 +7,9 @@ pub use digest::*;
 mod i32_flex;
 pub use i32_flex::*;
 
+mod string_flex;
+pub use string_flex::*;
+
 mod usage_accumulator;
 pub use usage_accumulator::*;
 

--- a/crates/pulsevm_core/src/chain/utils/string_flex.rs
+++ b/crates/pulsevm_core/src/chain/utils/string_flex.rs
@@ -1,0 +1,64 @@
+// Same story as I32Flex: Antelope clients (eosjs, proton-js, the explorer)
+// send bound/key parameters as either a string or a bare JSON number —
+// get_table_rows on Leap accepts both. Deserialize either into a String.
+
+use core::fmt;
+use serde::{
+    Deserialize, Deserializer, Serialize, Serializer,
+    de::{Error as DeError, Visitor},
+};
+
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct StringFlex(pub String);
+
+impl From<String> for StringFlex {
+    fn from(v: String) -> Self {
+        StringFlex(v)
+    }
+}
+impl From<StringFlex> for String {
+    fn from(v: StringFlex) -> Self {
+        v.0
+    }
+}
+
+impl Serialize for StringFlex {
+    fn serialize<S: Serializer>(&self, s: S) -> Result<S::Ok, S::Error> {
+        s.serialize_str(&self.0) // always serialize as a string
+    }
+}
+
+impl<'de> Deserialize<'de> for StringFlex {
+    fn deserialize<D: Deserializer<'de>>(de: D) -> Result<Self, D::Error> {
+        struct V;
+        impl<'de> Visitor<'de> for V {
+            type Value = StringFlex;
+
+            fn expecting(&self, f: &mut fmt::Formatter) -> fmt::Result {
+                write!(f, "a string or a number")
+            }
+
+            fn visit_i64<E: DeError>(self, v: i64) -> Result<Self::Value, E> {
+                Ok(StringFlex(v.to_string()))
+            }
+            fn visit_u64<E: DeError>(self, v: u64) -> Result<Self::Value, E> {
+                Ok(StringFlex(v.to_string()))
+            }
+            fn visit_f64<E: DeError>(self, v: f64) -> Result<Self::Value, E> {
+                if v.is_finite() && v.fract() == 0.0 {
+                    // bounds are table keys — integer-valued numbers only
+                    Ok(StringFlex(format!("{}", v as i64)))
+                } else {
+                    Err(E::custom("expected an integer-valued number or a string"))
+                }
+            }
+            fn visit_str<E: DeError>(self, s: &str) -> Result<Self::Value, E> {
+                Ok(StringFlex(s.to_string()))
+            }
+            fn visit_string<E: DeError>(self, s: String) -> Result<Self::Value, E> {
+                Ok(StringFlex(s))
+            }
+        }
+        de.deserialize_any(V)
+    }
+}


### PR DESCRIPTION
## Problem

`pulsevm.getTableRows` rejects the parameter shapes that standard Antelope clients send, so eosjs/proton-js apps — including the Metallicus explorer — get `-32602 Invalid params` and render empty tables.

Observed live (A-Chain testnet explorer, Oracles page — the Consensus Value pane is blank). The explorer's actual request:

```json
{"json":true,"code":"oracles","scope":"oracles","table":"data",
 "lower_bound":27,"upper_bound":27,"index_position":1,"key_type":"","limit":-1,...}
```

Three gaps vs Leap's `get_table_rows`:

1. **Numeric bounds rejected** — JS clients send numeric table keys as JSON numbers (`lower_bound: 27`). PulseVM declares `Option<String>` → `invalid type: integer, expected a string`. (Leap accepts string-or-number; eosjs has sent numbers since 2018.)
2. **`key_type` mandatory** — clients that omit it get `missing field key_type`. Optional in Leap.
3. **`limit: -1`** — eosjs convention for "no limit" became `u32::MAX` by accident of the old `as u32` cast; now handled explicitly.

The codebase already acknowledges this client behavior — `I32Flex` exists for exactly this reason (its comment says it best). This PR extends the same treatment to the string-typed params.

## Change

- New `StringFlex` (mirror of `I32Flex`): deserializes a string **or** a JSON number into a `String`; always serializes as a string.
- `getTableRows`: `scope`, `table_key`, `lower_bound`, `upper_bound` → `StringFlex`; `key_type` → `Option<String>`; negative `limit` → explicit "no limit".

All-string requests are unaffected (`StringFlex` is a superset). After this, the explorer's oracle pane, eosjs/proton-js table reads, and `pulse-cli` table queries work against PulseVM unchanged.
